### PR TITLE
fix: unescape match and search values from database

### DIFF
--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -325,7 +325,9 @@ class Database {
       const copyDate = iter.get_value_for_field('copyDate') as any as string;
       const isFavorite = iter.get_value_for_field('isFavorite') as any as string;
       const matchValue = iter.get_value_for_field('matchValue') as any as string;
+      const matchValue_unescaped = Gda5.default_unescape_string(matchValue) ?? matchValue;
       const searchValue = iter.get_value_for_field('searchValue') as any as string;
+      const searchValue_unescaped = Gda5.default_unescape_string(searchValue) ?? searchValue;
       const metaData = iter.get_value_for_field('metaData') as any as string;
 
       itemList.push({
@@ -334,8 +336,8 @@ class Database {
         content: content_unescaped,
         copyDate: new Date(copyDate),
         isFavorite: !!isFavorite,
-        matchValue,
-        searchValue,
+        matchValue: matchValue_unescaped,
+        searchValue: searchValue_unescaped,
         metaData,
       });
     }


### PR DESCRIPTION
# Add unescape for match and search values from database

## Description

**From @Totto16:** libgda escapes the string on inserting it into the db. You can't change that behavior (as far as my research goes) So the easiest method to fix this, is to unescape the string on retrieval.

**My part:** I've added unescapes for `searchValue` and `matchValue`. I've also tested the other content types and found no problems with escaping/unescaping. Libgda only escapes `'` and `\` according to the [documentation](https://valadoc.org/libgda-5.0/Gda.Default.escape_string.html). I don't think these are used in emoji/colors/images. I've also tested adding a `\` to a file name and found no problems.

- [x]  add other fields too ("searchValue" and "matchValue")
- [x] test other types of content too (image, emoji, color, etc.) and see if they need unescaping or not

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My commits follow the commit standards of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
